### PR TITLE
dmic: Update topology to expose volume control

### DIFF
--- a/dmic/dmic-multiconfig-tplg.xml
+++ b/dmic/dmic-multiconfig-tplg.xml
@@ -568,6 +568,10 @@
                     </Pipelines>
                 </Path>
             </Paths>
+            <VolumeMixer>
+                <Name>DMIC Volume</Name>
+                <Max>0x7FFFFFFF</Max>
+            </VolumeMixer>
         </PathTemplate>
         <PathTemplate id="1" widget_name="DMIC BE">
             <Paths>


### PR DESCRIPTION
Add volume control to DMIC path, allows user to change volume level on DMIC frontend.