### PR TITLE
i2s: max98357a: Topology updates

### DIFF
--- a/i2s/max98357a-tplg.xml
+++ b/i2s/max98357a-tplg.xml
@@ -62,7 +62,6 @@
 	    <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprBlobFormatId>2</CprBlobFormatId>
             <CprFeatureMask>0</CprFeatureMask>
-            <CprVirtualIndex>80</CprVirtualIndex>
             <CprDMAType>12</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
         </ModuleConfigExt>

--- a/i2s/max98357a-tplg.xml
+++ b/i2s/max98357a-tplg.xml
@@ -52,7 +52,7 @@
     <ModuleConfigsExt>
         <ModuleConfigExt id="0">
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
-            <CprOutAudioFormatId>0</CprOutAudioFormatId>
+            <CprOutAudioFormatId>2</CprOutAudioFormatId>
             <CprFeatureMask>0</CprFeatureMask>
             <CprDMAType>0</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
@@ -119,7 +119,7 @@
                             <Modules>
                                 <Module id="0">
                                     <ConfigBaseId>1</ConfigBaseId>
-                                    <InAudioFormatId>0</InAudioFormatId>
+                                    <InAudioFormatId>2</InAudioFormatId>
                                     <ConfigExtId>1</ConfigExtId>
                                 </Module>
                             </Modules>

--- a/i2s/max98357a-tplg.xml
+++ b/i2s/max98357a-tplg.xml
@@ -59,7 +59,7 @@
         </ModuleConfigExt>
         <ModuleConfigExt id="1">
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
-	    <CprOutAudioFormatId>1</CprOutAudioFormatId>
+            <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprBlobFormatId>2</CprBlobFormatId>
             <CprFeatureMask>0</CprFeatureMask>
             <CprDMAType>12</CprDMAType>


### PR DESCRIPTION
A range of fixes addressing:
- copier configuration for the speaker path, aligning with expectations and existing skylake-driver configuration
- utilizing dynamic-port-assignment feature of the avs-driver
- style fixes

Tested with Chromebooks: Nautilus and Nami.