### PR TITLE
i2s: nau8825: Fix time slot for BE playback copier

### DIFF
--- a/i2s/nau8825-tplg.xml
+++ b/i2s/nau8825-tplg.xml
@@ -71,6 +71,7 @@
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
             <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprFeatureMask>0</CprFeatureMask>
+            <CprVirtualIndex>2</CprVirtualIndex>
             <CprDMAType>12</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
         </ModuleConfigExt>


### PR DESCRIPTION
The expectation is that the playback on nau8825 codec runs with TDM slot 2. Update the BE copier description to reflect that.

Tested on Chell device.