### PR TITLE
i2s: da7219: Set correct BE format

### DIFF
--- a/i2s/da7219-tplg.xml
+++ b/i2s/da7219-tplg.xml
@@ -110,7 +110,7 @@
             <Paths>
                 <Path id="0">
                     <FEAudioFormatId>0</FEAudioFormatId>
-                    <BEAudioFormatId>0</BEAudioFormatId>
+                    <BEAudioFormatId>1</BEAudioFormatId>
                     <Pipelines>
                         <Pipeline id="0">
                             <BindingId>0</BindingId>
@@ -131,7 +131,7 @@
             <Paths>
                 <Path id="0">
                     <FEAudioFormatId>0</FEAudioFormatId>
-                    <BEAudioFormatId>0</BEAudioFormatId>
+                    <BEAudioFormatId>1</BEAudioFormatId>
                     <Pipelines>
                         <Pipeline id="0">
                             <ConfigId>0</ConfigId>
@@ -151,7 +151,7 @@
             <Paths>
                 <Path id="0">
                     <FEAudioFormatId>0</FEAudioFormatId>
-                    <BEAudioFormatId>0</BEAudioFormatId>
+                    <BEAudioFormatId>1</BEAudioFormatId>
                     <Pipelines>
                         <Pipeline id="0">
                             <BindingId>1</BindingId>
@@ -172,7 +172,7 @@
             <Paths>
                 <Path id="0">
                     <FEAudioFormatId>0</FEAudioFormatId>
-                    <BEAudioFormatId>0</BEAudioFormatId>
+                    <BEAudioFormatId>1</BEAudioFormatId>
                     <Pipelines>
                         <Pipeline id="0">
                             <ConfigId>0</ConfigId>


### PR DESCRIPTION
All known configurations use 48kHz, 2ch, 24/32bit BE format.

Note: this requires properly updated machine board on kernel side.