### PR TITLE
Fix parsing inlined nodes in formatxml

### DIFF
--- a/formatxml.pl
+++ b/formatxml.pl
@@ -83,7 +83,7 @@ while (<$INFILE>) {
 
 		# Push stack only when '>' is on its own.
 		# TODO: mixed '<node> <!-- comment -->' not supported.
-		if ($current_node !~ /[-|\/|\?]>$/) {
+		if ($current_node !~ /<\/|[-|\/|\?]>$/) {
 			$depth++;
 		}
 		$current_node = "";


### PR DESCRIPTION
A node may be provided in: <name>Value</name> fashion. Currently such construct increases the indentation-stack depth as '</' in the middle is not checked and the indentation gets messed up.

Fixes: 1dff9d4ff3c2 ("Add formatxml script")