### PR TITLE
i2s: Do not hardcode CprVirtualIndex

### DIFF
--- a/i2s/da7219-tplg.xml
+++ b/i2s/da7219-tplg.xml
@@ -57,7 +57,6 @@
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
             <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprFeatureMask>0</CprFeatureMask>
-            <CprVirtualIndex>16</CprVirtualIndex>
             <CprDMAType>13</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
         </ModuleConfigExt>
@@ -72,7 +71,6 @@
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
             <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprFeatureMask>0</CprFeatureMask>
-            <CprVirtualIndex>16</CprVirtualIndex>
             <CprDMAType>12</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
         </ModuleConfigExt>

--- a/i2s/nau8825-tplg.xml
+++ b/i2s/nau8825-tplg.xml
@@ -71,7 +71,6 @@
             <UUID>9BA00C83-CA12-4A83-943C-1FA2E82F9DDA</UUID>
             <CprOutAudioFormatId>1</CprOutAudioFormatId>
             <CprFeatureMask>0</CprFeatureMask>
-            <CprVirtualIndex>2</CprVirtualIndex>
             <CprDMAType>12</CprDMAType>
             <CprDMABufferSize>768</CprDMABufferSize>
         </ModuleConfigExt>


### PR DESCRIPTION
Kernel will set it to correct value based on platform definition, so there is no need to hardcode.