### PR TITLE
hda/i2s: Small set of closely-unrelated fixes

### DIFF
--- a/hda/hda-10ec0245-tplg.xml
+++ b/hda/hda-10ec0245-tplg.xml
@@ -1,0 +1,1 @@
+hda-generic-1ep-tplg.xml

--- a/hda/hda-generic-1ep-tplg.xml
+++ b/hda/hda-generic-1ep-tplg.xml
@@ -47,13 +47,13 @@
     </AudioFormats>
     <ModuleConfigsBase>
         <ModuleConfigBase id="0">
-            <Cpc>10000</Cpc>
+            <Cpc>11000</Cpc>
             <Ibs>192</Ibs>
             <Obs>192</Obs>
             <Pages>0</Pages>
         </ModuleConfigBase>
         <ModuleConfigBase id="1">
-            <Cpc>10000</Cpc>
+            <Cpc>11000</Cpc>
             <Ibs>384</Ibs>
             <Obs>384</Obs>
             <Pages>0</Pages>

--- a/i2s/rt1308-tplg.xml
+++ b/i2s/rt1308-tplg.xml
@@ -146,12 +146,12 @@
     </PathTemplates>
     <FEDAIs>
         <FEDAI name="Speaker">
-            <CaptureCapabilities>
+            <PlaybackCapabilities>
                 <Formats>32</Formats>
                 <Rates>48000</Rates>
                 <Channels>2</Channels>
-		<SigBits>24</SigBits>
-            </CaptureCapabilities>
+                <SigBits>24</SigBits>
+            </PlaybackCapabilities>
         </FEDAI>
     </FEDAIs>
     <Graphs>


### PR DESCRIPTION
Few fixes for unrelated issues.
* Update Cpc value in HDA topology to avoid warnings
* Fix playback FEDAI description
* Add HDA codec symlink to generic configuration